### PR TITLE
Downgraded the uber-jar dependency in order to test AEM-6.1 compatibi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.mickleroy</groupId>
     <artifactId>aem-sass-compiler</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Sass compiler for AEM</name>
@@ -150,8 +150,8 @@
         <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
-            <version>6.2.0-SP1</version>
+            <classifier>obfuscated-apis</classifier>
+            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
By changing the uber-jar dependency **version** (downgraded to 6.1.0) and **classifier** to "ubfuscated-apis" I was able to install the bundle with all dependencies satisfied.

I also changed the version SNAPSHOT to 1.1.0-SNAPSHOT (don't know which version control directives you're following)

Successfully tested on AEM 6.1.0.SP2-CFP10.

This code change may affect #1 , #2 and #3 