### PR TITLE
Add dependencies in CompilerContext

### DIFF
--- a/src/main/java/com/github/mickleroy/aem/sass/impl/FileImporter.java
+++ b/src/main/java/com/github/mickleroy/aem/sass/impl/FileImporter.java
@@ -79,6 +79,7 @@ public class FileImporter implements Importer {
         }
 
         ScriptResource resource = null;
+        String resourcePath = null;
         String currentDir  = getCurrentDirectory(previous);
         String pathToFile  = getPathToFile(url);
         String getFileName = getFileName(url);
@@ -94,6 +95,7 @@ public class FileImporter implements Importer {
             resource = getResource(pathToImport);
 
             if(resource != null) {
+                resourcePath = pathToImport;
                 break;
             }
         }
@@ -104,6 +106,7 @@ public class FileImporter implements Importer {
         }
 
         try {
+            context.getDependencies().add(resourcePath);
             return Collections.singletonList(new Import(
                     new URI(resource.getName()),
                     new URI(resource.getName()),

--- a/src/test/java/com/github/mickleroy/aem/sass/impl/SassCompilerImplTest.java
+++ b/src/test/java/com/github/mickleroy/aem/sass/impl/SassCompilerImplTest.java
@@ -66,7 +66,8 @@ public class SassCompilerImplTest {
     @Test
     public void testCompile() throws IOException {
         String inputScss = "html { p { color: red; } }";
-        String outputCss = "html p {\n  color: red; }\n";
+        // use String.format to ensure platform-dependent line separator
+        String outputCss = String.format("html p {%n  color: red; }%n");
         PrintWriter out = spy(new PrintWriter(File.createTempFile("aem-sass-compiler", "")));
         when(mockScriptResource.getReader()).thenReturn(new InputStreamReader(IOUtils.toInputStream(inputScss)));
 


### PR DESCRIPTION
Adding dependencies in CompilerContext should allow the generated files to be invalidated when one dependency is modified.

Should fix #4

Tested with AEM 6.2

(Also includes a test fix on Windows)